### PR TITLE
Added option to allow specifying width of \Qlines

### DIFF
--- a/latex-surveys.tex
+++ b/latex-surveys.tex
@@ -58,8 +58,14 @@
 
 %% \Qlines = Insert NUM lines with width=\linewith. You can change the
 %% \vskip value to adjust the spacing.
+%\newcounter{ql}
+%\newcommand{\Qlines}[1]{\forloop{ql}{0}{\value{ql}<#1}{\vskip0em\Qline{\linewidth}}}
+
+% added new \Qlines argument with ability to specify line width, use \Qlines[number][width]
+% default width remains \linewidth for compatability
+\usepackage{xparse}
 \newcounter{ql}
-\newcommand{\Qlines}[1]{\forloop{ql}{0}{\value{ql}<#1}{\vskip0em\Qline{\linewidth}}}
+\DeclareDocumentCommand{\Qlines}{o O{\linewidth}}{\forloop{ql}{0}{\value{ql}<#1}{\vskip0em\Qline{#2}}}
 
 %% \Qlist = This is an environment very similar to itemize but with
 %% \QO in front of each list item. Useful for classical multiple

--- a/latex-surveys.tex
+++ b/latex-surveys.tex
@@ -144,6 +144,8 @@ create more complex layout.}
 
 \Qitem{ \Qq{How old are you?} I am \Qline{1.5cm} years old.}
 
+\Qitem{ \Qq{Address}: \Qlines[4][8cm] }
+
 \Qitem{ \Qq{Are you in a good mood right now?} \hskip0.4cm \QO{}
 absolutely \hskip0.5cm \QO{} not really because: \Qline{3cm} }
 


### PR DESCRIPTION
I was looking for a way to specify multi-line fields that don't span the whole \linewidth.
Hopefully it's useful to others.
Thanks for the collection of macros, saved me a lot of time!